### PR TITLE
choose which lpc1768 timer to use for us_ticker.c

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC176X/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/us_ticker.c
@@ -28,8 +28,19 @@ const ticker_info_t* us_ticker_get_info()
 
 static bool us_ticker_inited = false;
 
+#if MBED_CONF_TARGET_US_TICKER_TIMER == 0
+#define US_TICKER_TIMER      ((LPC_TIM_TypeDef *)LPC_TIM0_BASE)
+#define US_TICKER_TIMER_IRQn TIMER0_IRQn
+#elif MBED_CONF_TARGET_US_TICKER_TIMER == 1
+#define US_TICKER_TIMER      ((LPC_TIM_TypeDef *)LPC_TIM1_BASE)
+#define US_TICKER_TIMER_IRQn TIMER1_IRQn
+#elif MBED_CONF_TARGET_US_TICKER_TIMER == 1
+#define US_TICKER_TIMER      ((LPC_TIM_TypeDef *)LPC_TIM2_BASE)
+#define US_TICKER_TIMER_IRQn TIMER2_IRQn
+#else
 #define US_TICKER_TIMER      ((LPC_TIM_TypeDef *)LPC_TIM3_BASE)
 #define US_TICKER_TIMER_IRQn TIMER3_IRQn
+#endif
 
 void us_ticker_init(void) {
     if (us_ticker_inited) {

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -247,6 +247,12 @@
         "release_versions": ["2", "5"],
         "device_name": "LPC1768",
         "bootloader_supported": true,
+        "config": {
+            "us-ticker-timer": {
+                "help": "Chooses which timer (0-3) to use for us_ticker.c",
+                "value": 3
+            }
+        },
         "overrides": {
             "network-default-interface-type": "ETHERNET"
         }


### PR DESCRIPTION
### Description
Adding option for LPC1768 by which user can select which timer to use for us_ticker.c
LPC1768 has available timers: 0, 1, 2 and 3.  The default uses the original coded timer: timer 3.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Breaking change

